### PR TITLE
Revisio hackupc 2024

### DIFF
--- a/_documents/code_of_conduct.md
+++ b/_documents/code_of_conduct.md
@@ -37,10 +37,9 @@ By sending us an email to contact@hackupc.com, your report will be received by o
 
 If you need to contact a team member directly, please contact one of our organizers below.
 
-- Carlota Catot, **@Carlota** in Slack, [carlota@hackupc.com](mailto:carlota@hackupc.com).
-- Eric Serrano, **@Eric** in Slack, [eric@hackupc.com](mailto:eric@hackupc.com).
-- Joel Miarons, **@Joel** in Slack, [joel@hackupc.com](mailto:joel@hackupc.com).
+- Gerard Madrid, **@awakt** in Slack, [gerard.madrid@hackupc.com](mailto:gerard.madrid@hackupc.com).
+- Teresa Rovira, **@terocar** in Slack, [teresa@hackupc.com](mailto:teresa@hackupc.com).
 
 Hackers@UPC reserves the right to revise, make exceptions to, or otherwise amend these policies in whole or in part.
 
-Last Reviewed: April 4, 2023.
+Last Reviewed: January 1st, 2024.

--- a/_documents/privacy_and_cookies.md
+++ b/_documents/privacy_and_cookies.md
@@ -25,19 +25,19 @@ Here are the details of which personal data is collected when you register as a 
 
 - Identifying data: Name, surname/s, city, country of residence, images or videos of yourself and a link to a personal website.
 - Contact data: E-mail and phone number.
-- Data on personal characteristics: Sex, if you are a minor and t-shirt size.
+- Data on personal characteristics: Gender identity, if you are a minor and t-shirt size.
 - Academic and professional data: CV, year of graduation, university/school, current studies and a link to professional profiles on-line (github, linkedin, devpost).
 - Economic and financial data: E-mail related to your PayPal account.
-- Health data: Food allergies and intolerances.
+- Health data: Dietary requirements such as food allergies and intolerances.
 - Other information: Account password, last connection and dietary preferences.
 
 Here are the details of which personal data is collected when you register as a Volunteer:
 
-- Identifying data: Name, surname/s and images or videos of yourself.
+- Identifying data: Name, surname/s, city, country of residence, and images or videos of yourself.
 - Contact data: E-mail and phone number.
-- Data on personal characteristics: Sex, if you are a minor, t-shirt size.
+- Data on personal characteristics: Gender identity, if you are a minor, t-shirt size.
 - Academic and professional data: University/School, current studies and previous experience.
-- Health data: Food allergies and intolerances.
+- Health data: Dietary requirements such as food allergies and intolerances.
 - Other information: Account password and dietary preferences.
 
 Here are the details of which personal data is collected when you register as an Organizer:
@@ -47,7 +47,7 @@ Here are the details of which personal data is collected when you register as an
 - Business contact data: Corporate e-mail.
 - Data on personal characteristics: T-shirt size.
 - Economic and financial data: Bank account.
-- Health data: Food allergies and intolerances.
+- Health data: Dietary requirements such as food allergies and intolerances.
 - Other information: Account password, last connection and dietary preferences.
 - Academic Data and professional data: CV, Current studies, year of studies, link to professional profiles online (GitHub, LinkedIn).
 
@@ -55,8 +55,8 @@ Here are the details of which personal data is collected when you register as a 
 
 - Identifying data: Name, surname/s, images or videos of yourself and links to social media and personal websites.
 - Contact data: E-mail and phone number.
-- Data on personal characteristics: Sex and t-shirt size.
-- Health data: Food allergies and intolerances.
+- Data on personal characteristics: Gender identity and t-shirt size.
+- Health data: Dietary requirements such as food allergies and intolerances.
 - Other information: Account password, last connection and dietary preferences.
 - Academic Data and professional data: Current or completed studies, university, year of graduation, current job position, link to professional profiles online (Github, Linkedin)
 
@@ -64,16 +64,16 @@ Here are the details of which personal data is collected when you register as a 
 
 - Identifying data: Name, surname/s, and images or videos of the contact person or the employee of the Sponsor.
 - Business contact data: Corporate e-mail of the contact person or the employee of the Sponsor. We also collect what company you are working for currently as well as your Job position.
-- Data on personal characteristics: Sex and t-shirt size.
-- Health data: Food allergies and intolerances.
+- Data on personal characteristics: Gender identity and t-shirt size.
+- Health data: Dietary requirements such as food allergies and intolerances.
 - Other information: Dietary preferences.
 
 Here are the details of which personal data is collected when you register as "other attendees/users":
 
 - Identifying data: Name, surname/s and images or videos of yourself.
 - Contact data: e-mail.
-- Data on personal characteristics: Sex and t-shirt size
-- Health data: Food allergies and intolerances.
+- Data on personal characteristics: Gender identity and t-shirt size
+- Health data: Dietary requirements such as food allergies and intolerances.
 - Other information: Dietary preferences.
 
 Here are the details of which personal data is collected during a HackUPC CHEATING RESPONSE PROCEDURE:
@@ -304,4 +304,4 @@ Everything related to Google's cookies, both analytical and advertising, as well
 
 If you choose to disable cookies, we may not be able to offer you some of our services.
 
-Last Reviewed: January 1st, 2024.
+Last Reviewed: February 2nd, 2024.

--- a/_documents/privacy_and_cookies.md
+++ b/_documents/privacy_and_cookies.md
@@ -304,4 +304,4 @@ Everything related to Google's cookies, both analytical and advertising, as well
 
 If you choose to disable cookies, we may not be able to offer you some of our services.
 
-Last Reviewed: February 2nd, 2024.
+Last Reviewed: February 7th, 2024.

--- a/_documents/privacy_and_cookies.md
+++ b/_documents/privacy_and_cookies.md
@@ -112,9 +112,11 @@ Regarding the images and videos of yourself:
 
 - Sponsors shall process your personal data to display, broadcast and/or publish it by Sponsors for advertising purposes through any audiovisual and/or written media (TV, press, internet, social networks, etc.) and in any advertising and media support (brochures, banners, panels, website, memory of activities, publications, reports, etc.).
 
+- Partners shall process your personal data to display, broadcast and/or publish it by Partners for advertising purposes through any audiovisual and/or written media (TV, press, internet, social networks, etc.) and in any advertising and media support (brochures, banners, panels, website, memory of activities, publications, reports, etc.).
+
 Regarding food allergies and intolerances:
 
-- HACKERS AT UPC shall process your personal data only in order to manage the catering service.
+- HACKERS AT UPC shall process your personal data only in order to manage the catering services hired for the event.
 
 ## 4. WHY WE MAY PROCESS YOUR PERSONAL DATA
 
@@ -302,4 +304,4 @@ Everything related to Google's cookies, both analytical and advertising, as well
 
 If you choose to disable cookies, we may not be able to offer you some of our services.
 
-Last Reviewed: April 6, 2023.
+Last Reviewed: January 1st, 2024.

--- a/_documents/terms_and_conditions.md
+++ b/_documents/terms_and_conditions.md
@@ -267,4 +267,4 @@ This Agreement may be executed in counterparts or online, which taken together s
 
 This Agreement shall be binding upon and inure solely to the benefit of the parties hereto and their permitted assigns and nothing herein, express or implied, is intended to or shall confer upon any other person any legal or equitable right, benefit or remedy of any nature whatsoever under or by reason of this Agreement."
 
-Last Reviewed: February 2nd, 2024.
+Last Reviewed: February 7th, 2024.

--- a/_documents/terms_and_conditions.md
+++ b/_documents/terms_and_conditions.md
@@ -42,7 +42,7 @@ Remember that Hackathons are like marathons. Some people go to compete, but most
 ### The rules of the competition
 
 1. There is no minimum team size, however, the maximum size is 4 people. There will be 1 prize for each member of the team, independently of the team size.
-1. Every team can only submit up to one project, although they can apply to multiple sponsor prizes with said project. 
+1. Every team can only submit up to one project, although they can apply to multiple sponsor challenges and win multiple prizes with said project. 
 1. Teams should be made up exclusively of students (or recent graduates within one year of having graduated) who are not organizers, judges, sponsors, or in any other privileged position at the event. Volunteers are allowed to participate in their free time, accepting the extra difficulty of hacking and volunteering at the same time, but their role won't give them any judging advantage in front of the rest of participants.
 1. All team members should be accepted into the hackathon by the organization and registered into the online platforms used before and during the event.
 1. All team members should be reachable by any member of the organization team during the event.

--- a/_documents/terms_and_conditions.md
+++ b/_documents/terms_and_conditions.md
@@ -267,4 +267,4 @@ This Agreement may be executed in counterparts or online, which taken together s
 
 This Agreement shall be binding upon and inure solely to the benefit of the parties hereto and their permitted assigns and nothing herein, express or implied, is intended to or shall confer upon any other person any legal or equitable right, benefit or remedy of any nature whatsoever under or by reason of this Agreement."
 
-Last Reviewed: January 1st, 2024.
+Last Reviewed: February 2nd, 2024.

--- a/_documents/terms_and_conditions.md
+++ b/_documents/terms_and_conditions.md
@@ -42,6 +42,7 @@ Remember that Hackathons are like marathons. Some people go to compete, but most
 ### The rules of the competition
 
 1. There is no minimum team size, however, the maximum size is 4 people. There will be 1 prize for each member of the team, independently of the team size.
+1. Every team can only submit up to one project, although they can apply to multiple sponsor prizes with said project. 
 1. Teams should be made up exclusively of students (or recent graduates within one year of having graduated) who are not organizers, judges, sponsors, or in any other privileged position at the event. Volunteers are allowed to participate in their free time, accepting the extra difficulty of hacking and volunteering at the same time, but their role won't give them any judging advantage in front of the rest of participants.
 1. All team members should be accepted into the hackathon by the organization and registered into the online platforms used before and during the event.
 1. All team members should be reachable by any member of the organization team during the event.
@@ -266,4 +267,4 @@ This Agreement may be executed in counterparts or online, which taken together s
 
 This Agreement shall be binding upon and inure solely to the benefit of the parties hereto and their permitted assigns and nothing herein, express or implied, is intended to or shall confer upon any other person any legal or equitable right, benefit or remedy of any nature whatsoever under or by reason of this Agreement."
 
-Last Reviewed: February 06, 2023.
+Last Reviewed: January 1st, 2024.


### PR DESCRIPTION
**Afegit:**
- Els partners ara poden rebre i processar la imatge dels hackers per activitats propies
- Nova norma de la competició: només es pot participar amb un sol projecte.

**Corregit:**
- Canvi de directors
- Canvis de applications de hackers i voluntaris
- Canvis a la informació recollida a les applications (sex -> gender identity)