### PR TITLE
afegir terms and conditions talks

### DIFF
--- a/_documents/talks_terms_and_conditions.md
+++ b/_documents/talks_terms_and_conditions.md
@@ -1,0 +1,127 @@
+---
+layout: document
+title: "Talks & Workshops Terms and Conditions"
+category: talks_and_workshops
+---
+# Talks & Workshops Terms and Conditions
+
+These Terms & Conditions (hereinafter, "T&C") are intended to regulate the relationship between ASSOCIACIÓ HACKERS AT UPC (hereinafter, "HACKERS AT UPC") and the Users who decide to sign up and participate in the event Talks & Workshops organized by HACKERS AT UPC.
+
+For the purposes of this Agreement, the parties agree that, when used capitalized herein, the following terms shall have the following meanings unless they are otherwise defined in this Agreement.
+
+## DEFINITIONS
+
+**The "Organizer"** refers to HACKERS AT UPC, with NIF/VAT G66642778 and address at C/ Jordi Girona, num. 1, Campus Nord UPC, Edifici Omega, D.S102, 08034, Barcelona (Spain) and contact e-mail address [info@hackersatupc.org](mailto:info@hackersatupc.org).
+
+**The event "Talks & Workshops"** refers to the Event organized by the **Organizer**, which is an educational conference. In these conferences, tech or college related subjects are shared with the students and attendees. These conferences take place in a hybrid format, with both an on-site location as well as a live streaming. The Talks & Workshops event may take place several times throughout the year.
+
+**The "Attendee"** refers to any User who decides to sign up accepting these T&C and participates in the event organized by the Organizer by attending the Talk or Workshop.
+
+**The "Swag"** refers to any gift provided by **The Organizer** in any physical or online form with no cost.
+
+## CLAUSES
+
+## 1. OBJECT
+
+By virtue of this Agreement, the Attendee agrees to participate in the event Talks & Workshops organized by HACKERS AT UPC.
+
+This T&C applies to the Attendees, although some of its clauses may only apply depending on the way the Attendee takes part in the event.
+
+HACKERS AT UPC is an association that promotes technology, creativity, and innovation and organizes events, primarily Hackathons, which take place once a year.
+
+
+## 2. TERMINATION AND CANCELLATION
+
+HACKERS AT UPC may at any time, in its sole discretion, immediately terminate this Agreement with or without cause. HACKERS AT UPC will make commercially reasonable efforts to notify the Attendee via e-mail of any such termination or cancellation up to the date of the event.
+
+Attendees may cancel and/or terminate this Agreement with or without cause at any time, always notifying HACKERS AT UPC in a reasonable period of time.
+
+If either party does not fulfil a material obligation defined in this Agreement, the other party has the right to terminate this Agreement immediately with written notice to the party in breach, provided that such material breach remains uncured, without prejudice of the right to claim the damages caused to the non-breaching party.
+
+## 3. CONFIDENTIALITY, PERSONAL DATA PROTECTION AND RIGHTS OF IMAGE
+
+In accordance with the current data protection legislation, particularly the Regulation (EU) 2016/679 of The European Parliament and of The Council, of 27 April, on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, all personal data collected during the use of the Website will be processed in accordance with the provisions of the [Privacy and Cookies Policy](https://legal.hackersatupc.org/talks_and_workshops/talks_privacy_and_cookies) which all Users must expressly accept.
+
+As it is explained in the Privacy Policy, one of the personal data that you authorize HACKERS AT UPC to process is your image:
+
+- By accepting the Privacy and Cookies Policy and these T&C you grant HACKERS AT UPC permission to capture photographs and/or record videos of yourself in the event you request to participate.
+- You give your consent for the images and/or videos taken during the course of this event to be displayed, broadcasted and/or published by HACKERS AT UPC for advertising purposes through any audiovisual and/or written media (TV, press, internet, social networks, etc.) and in any advertising and media support (brochures, banners, panels, website, memory of activities, publications, reports, etc.), worldwide, for an indefinite period and without limitation.
+- This authorization is perpetual and has no other limitations than those contained in the Spanish Organic Law 1/1982, of May 5, on Civil Protection of the right to honor, personal and family privacy and self-image.
+- This authorization is made completely free of charge, and you undertake not to request or claim any compensation, payment or reimbursement in exchange for this authorization.
+- When the photographs and/or videos are taken by HACKERS AT UPC, the applicable Privacy Policy will be the HACKERS AT UPC's Privacy and Cookies Policy.
+
+## 4. LIMITATION OF LIABILITY AND INDEMNIFICATION
+
+### Indemnification
+
+You agree to indemnify, defend and hold HACKERS AT UPC, its members (hosts and volunteers) and other personalities that have a role in this event (sponsors, judges, mentors) harmless from and against any and all costs, claims, demands, liabilities, expenses, losses, damages and attorney fees arising from any claims and lawsuits or proceeding for libel, slander, copyright, and trademark violation as well as all other claims resulting from (i) the participation in the event Talks & Workshops or (ii) otherwise arising from a relationship with HACKERS AT UPC. You also agree to indemnify HACKERS AT UPC for any legal fees incurred by HACKERS AT UPC, acting reasonably, in investigating or enforcing its rights under this Agreement.
+
+### Limitation of Liability
+
+UNDER NO CIRCUMSTANCES WILL HACKERS AT UPC BE LIABLE TO THE ATTENDEE WITH RESPECT TO ANY SUBJECT MATTER OF THESE TERMS AND CONDITIONS UNDER CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHER LEGAL OR EQUITABLE THEORY, WHETHER OR NOT HACKERS AT UPC HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE, FOR INDIRECT, INCIDENTAL, CONSEQUENTIAL, SPECIAL OR EXEMPLARY DAMAGES ARISING FROM ANY PROVISION OF THESE TERMS. THESE LIMITATIONS SHALL APPLY NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE.
+
+## 5. MODIFICATIONS
+
+HACKERS AT UPC reserves the right to amend the provisions of the present Agreement that are minor in scope or nature, and to do so without citing any reasons, provided such modifications do not lead to the Agreement as a whole being restructured. HACKERS AT UPC will communicate, by e-mail or other electronic means, the modified conditions at least 15 days prior to the Effective Date. Attendees who do not object in writing to the modification within 7 days after the receipt of the communication will be deemed to have accepted the respective modification.
+
+If an Attendee objects to the new (modified) Terms, HACKERS AT UPC´s request to modify them will be deemed to have been rejected. The Agreement will then be continued without the proposed modification only in relation to such particular event where the change was made while the Attendee was already registered, however, the new T&C with all modifications will fully apply for any new event. The right of the parties to terminate their participation in the event Talks & Workshops remains unaffected hereby.
+
+## 6. APPLICABLE LAW AND JURISDICTION
+
+This Agreement shall be governed by Spanish law.
+
+In the event that the User's domicile is outside Spain, HACKERS AT UPC and the Attendee, expressly waiving any other jurisdiction to which they may be entitled, hereby submit to the jurisdiction of the Courts and Tribunals of Barcelona.
+
+HACKERS AT UPC will pursue the breach of this Agreement by exercising all civil and criminal actions that may correspond.
+
+## 7. GENERAL PROVISIONS
+
+### Force Majeure
+
+Except for payment obligations, if either party is prevented from performing or is unable to perform any of its obligations under this Agreement due to causes beyond the reasonable control of the party invoking this provision, including but not limited to acts of God, acts of civil or military authorities, riots or civil disobedience, wars, strikes or labor disputes (each, a "Force Majeure Event"), such party's performance shall be excused and the time for performance shall be extended accordingly provided that the party immediately takes all reasonably necessary steps to resume full performance. If such party remains unable to resume full performance fifteen (15) days after the Force Majeure Event, the other party may terminate this Agreement upon written notice.
+
+### Severability
+
+Should any of the provisions of this Agreement be adjudged invalid or unenforceable by the rules and regulations of Spain or a Spanish court, such provisions shall be deemed several from the remainder of this Agreement and not affect the validity or enforceability of the remainder of this Agreement. In that case, such provisions shall be changed and interpreted to achieve the purposes of those provisions as much as possible within the extent of relevant laws or judgment of the court.
+
+### Survival
+
+Clauses 5, 6 and 9 shall survive termination or expiration of this Agreement for any reason. All other rights and obligations of the parties under this Agreement shall expire upon termination of this Agreement, except that all payment obligations accrued hereunder prior to termination or expiration shall survive such termination.
+
+### Assignment
+
+HACKERS AT UPC is hereby authorized to assign, sublicense, delegate or otherwise transfer any of its rights or obligations under this Agreement without the prior written consent of the other party provided that the assignee shall assume all rights and obligations under this Agreement
+
+The Attendee shall not assign, sublicense, delegate or otherwise transfer any of its rights or obligations.
+
+### Notices
+
+All notices and other communications hereunder shall be in writing and shall be deemed to have been duly given when delivered in person (including by internationally recognized commercial delivery service), and on the day the notice is sent when sent by email with confirmation receipt, if the time of transmission is during recipient's business day, or if not on the next business day thereafter, in each case to the respective parties at the postal or email addresses provided by them in writing.
+
+Either party may change its address by providing the other party with written notice of the change in accordance with this section.
+
+### Relationship of Parties
+
+The parties are independent contractors and will have no right to assume or create any obligation or responsibility on behalf of the other party. Neither party shall hold itself out as an agent of the other party. This Agreement will not be construed to create or imply any employment relationship, partnership, agency, joint venture or formal business entity of any kind.
+
+### Waiver
+
+No delay or failure by either party to exercise any right or remedy under this Agreement will constitute a waiver of such right or remedy. All waivers must be in writing and signed by an authorized representative of the party waiving its rights. A waiver by any party of any breach or covenant shall not be construed as a waiver of any succeeding breach of any other covenant.
+
+### Entire Agreement
+
+This Agreement constitutes the entire agreement between the parties and supersedes all previous agreements, oral or written, with respect to the subject matter of this Agreement. The information and documents provided by the Attendee to HACKERS AT UPC, as requested by the latest in order to enter the Agreement, shall be also considered as part of this Agreement. This Agreement may not be amended without the written consent of the parties.
+
+### Headings
+
+The headings of the articles and paragraphs contained in this Agreement are inserted for convenience and are not intended to be part of or to affect the interpretation of this Agreement.
+
+### Counterparts
+
+This Agreement may be executed in counterparts or online, which taken together shall form one legal instrument.
+
+### No Third Party Beneficiaries
+
+This Agreement shall be binding upon and inure solely to the benefit of the parties hereto and their permitted assigns and nothing herein, express or implied, is intended to or shall confer upon any other person any legal or equitable right, benefit or remedy of any nature whatsoever under or by reason of this Agreement."
+
+Last Reviewed: April 2nd, 2024.

--- a/_documents/talks_terms_and_conditions.md
+++ b/_documents/talks_terms_and_conditions.md
@@ -54,7 +54,7 @@ As it is explained in the Privacy Policy, one of the personal data that you auth
 
 ### Indemnification
 
-You agree to indemnify, defend and hold HACKERS AT UPC, its members (hosts and volunteers) and other personalities that have a role in this event (sponsors, judges, mentors) harmless from and against any and all costs, claims, demands, liabilities, expenses, losses, damages and attorney fees arising from any claims and lawsuits or proceeding for libel, slander, copyright, and trademark violation as well as all other claims resulting from (i) the participation in the event Talks & Workshops or (ii) otherwise arising from a relationship with HACKERS AT UPC. You also agree to indemnify HACKERS AT UPC for any legal fees incurred by HACKERS AT UPC, acting reasonably, in investigating or enforcing its rights under this Agreement.
+You agree to indemnify, defend and hold HACKERS AT UPC, its members (hosts) harmless from and against any and all costs, claims, demands, liabilities, expenses, losses, damages and attorney fees arising from any claims and lawsuits or proceeding for libel, slander, copyright, and trademark violation as well as all other claims resulting from (i) the participation in the event Talks & Workshops or (ii) otherwise arising from a relationship with HACKERS AT UPC. You also agree to indemnify HACKERS AT UPC for any legal fees incurred by HACKERS AT UPC, acting reasonably, in investigating or enforcing its rights under this Agreement.
 
 ### Limitation of Liability
 


### PR DESCRIPTION
Afegir nou documents **talks_terms_and_conditions**:

- Els rols estan limitats a organizer i attendee, pel que s'ha eliminat tota menció a sponsors, partners.
- Pel que he pogut veure, es farà streaming, així que indico que es fan en format híbrid.
- No hi ha code of conduct, competition rules, ni cheating response procedure
- canviat mail de contacte a info hackers